### PR TITLE
Trailing L on 0xFFFFFFFFFFFFFFFFL is no longer required

### DIFF
--- a/ida/idaapi.py
+++ b/ida/idaapi.py
@@ -55,7 +55,7 @@ sys.__ghidra_state__ = _state
 
 # Assume program bitness based on the first memory block pointer size
 BADADDR = ea_t.init(
-    0xFFFFFFFFFFFFFFFFL if _currentProgram.getMinAddress().getPointerSize() == 8 else 0xFFFFFFFF,
+    0xFFFFFFFFFFFFFFFF if _currentProgram.getMinAddress().getPointerSize() == 8 else 0xFFFFFFFF,
     Address.NO_ADDRESS)
 
 


### PR DESCRIPTION
The trailing L is a syntax error in Python 3 and is no longer required in Python 2.

[flake8](http://flake8.pycqa.org) testing of https://github.com/daenerys-sre/source on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./ida/idaapi.py:58:23: E999 SyntaxError: invalid syntax
    0xFFFFFFFFFFFFFFFFL if _currentProgram.getMinAddress().getPointerSize() == 8 else 0xFFFFFFFF,
                      ^
1     E999 SyntaxError: invalid syntax
1
```